### PR TITLE
Hash

### DIFF
--- a/src/cvplot/color.cc
+++ b/src/cvplot/color.cc
@@ -31,7 +31,11 @@ Color Color::index(uint8_t index, uint8_t density, float avoid,
 }
 
 Color Color::hash(const std::string &seed) {
-  return Color::index(std::hash<std::string>{}(seed));
+  unsigned hash = 37;
+  for (char c: seed) {
+     hash = (hash * 54059) ^ (c * 76963);
+  }
+  return Color::index(hash);
 }
 
 Color Color::uniq(const std::string &name) {

--- a/src/demo/demo.cc
+++ b/src/demo/demo.cc
@@ -266,6 +266,8 @@ void demo() {
       view.finish();
       view.flush();
     }
+    view.drawTextShadow("Press any key to exit", {70, 130}, cvplot::Red, 40.f);
+    view.flush();
   }
 }
 
@@ -343,5 +345,7 @@ int main(int argc, char **argv) {
   demo::example();
   demo::transparency();
   demo::demo();
+  printf("Demo completed. Ctrl+C to exit.\n");
+  cvplot::waitKey();
   return 0;
 }

--- a/test/cvplot/color_test.cc
+++ b/test/cvplot/color_test.cc
@@ -72,9 +72,9 @@ TEST(ColorTest, Index) {
 
 TEST(ColorTest, Hash) {
   Color c = Color::hash("test");
-  EXPECT_EQ(c.r, 160);
-  EXPECT_EQ(c.g, 4);
-  EXPECT_EQ(c.b, 218);
+  EXPECT_EQ(c.r, 94);
+  EXPECT_EQ(c.g, 37);
+  EXPECT_EQ(c.b, 251);
   EXPECT_EQ(c.a, 255);
 }
 


### PR DESCRIPTION
std::hash has varying implementations across platforms, resulting in failing tests. Make implementation fixed.